### PR TITLE
Add .gitignore for Jekyll/Ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Jekyll build output
+_site/
+
+# Bundler dependencies
+.bundle/
+vendor/
+
+# Gemfile lock
+Gemfile.lock
+
+# Mac system files
+.DS_Store
+
+# Swap files
+*.swp
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- ignore generated `_site` directory
- ignore bundler directories
- ignore `Gemfile.lock`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840651e631c832e878861c2db6cc166