### PR TITLE
Add GitHub Actions workflow for Jekyll build

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,29 @@
+name: Build Jekyll site
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build
+
+      - name: Upload generated site
+        uses: actions/upload-artifact@v3
+        with:
+          name: site
+          path: ${{ github.workspace }}/_site


### PR DESCRIPTION
## Summary
- add workflow to install Ruby deps and build Jekyll site
- upload resulting `_site` as artifact

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6840652c2688832e93d02392148405cd